### PR TITLE
Add hyperlinks to English version documents

### DIFF
--- a/GETTING_STARTED_KR.md
+++ b/GETTING_STARTED_KR.md
@@ -1,4 +1,5 @@
 # 시작하기
+[English](GETTING_STARTED.md) | 한글
 
 euphony는 사람에게 들리지 않는 가청주파수 임계대역을 활용해 데이터를 전송하는 라이브러리입니다.  
 API는 Java로 작성되어 있기 때문에 사용자는 Java 또는 Kotlin과 같은 JVM에서 동작하는 모든 언어에서 사용 가능합니다.  


### PR DESCRIPTION
What a kind document! It was very helpful to understand the library.
I propose the following improvements:
Add hyperlinks to English version documents for consistency in GETTING_STARTED documents.

# English version
![image](https://user-images.githubusercontent.com/47289893/131102571-0d7f76fc-f764-423a-935f-96ee8dbbf72d.png)

# Changes
# Before
![image](https://user-images.githubusercontent.com/47289893/131102249-040ccdd5-efd5-4b46-93cf-bc5759a2bdf0.png)

# After
![image](https://user-images.githubusercontent.com/47289893/131102440-f6d39ed0-f1f2-477d-b99b-140aa1913792.png)
