### PR TITLE
Add Korean language (UTF-8) support

### DIFF
--- a/euphony/src/main/cpp/CMakeLists.txt
+++ b/euphony/src/main/cpp/CMakeLists.txt
@@ -26,6 +26,7 @@ set(EUPHONY_SRC
         arms/kiss_fftr.c
         core/source/AudioStreamCallback.cpp
         core/source/ASCIICharset.cpp
+        core/source/UTF8Charset.cpp
         core/source/Base2.cpp
         core/source/Base16.cpp
         core/source/Base16Exception.cpp

--- a/euphony/src/main/cpp/core/UTF8Charset.h
+++ b/euphony/src/main/cpp/core/UTF8Charset.h
@@ -1,0 +1,17 @@
+#ifndef EUPHONY_UTF8CHARSET_H
+#define EUPHONY_UTF8CHARSET_H
+
+#include "Charset.h"
+
+namespace Euphony {
+
+    class UTF8Charset : public Charset {
+    public:
+        UTF8Charset() = default;
+        ~UTF8Charset() = default;
+        HexVector encode(std::string src);
+        std::string decode(const HexVector &src);
+    };
+}
+
+#endif //EUPHONY_UTF8CHARSET_H

--- a/euphony/src/main/cpp/core/source/UTF8Charset.cpp
+++ b/euphony/src/main/cpp/core/source/UTF8Charset.cpp
@@ -1,0 +1,26 @@
+#include "UTF8Charset.h"
+
+#include <iostream>
+#include <string>
+
+using namespace Euphony;
+
+HexVector UTF8Charset::encode(std::string src) {
+    HexVector result = HexVector(src.size());
+
+    for (int i = 0; i < src.size(); i++)
+        result.pushBack(src[i]);
+
+    return result;
+}
+
+std::string UTF8Charset::decode(const HexVector& src) {
+    std::string result;
+    std::vector<u_int8_t> hexSource = src.getHexSource();
+
+    for (int i = 0; i < hexSource.size() / 2; i++)
+        result += (hexSource[2 * i] << 4) | hexSource[2 * i + 1];
+
+    return result;
+}
+

--- a/euphony/src/main/cpp/tests/CMakeLists.txt
+++ b/euphony/src/main/cpp/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ target_include_directories (gtest PUBLIC ${GOOGLETEST_ROOT}/include)
 add_executable(
         ${TEST_EUPHONY}
         asciiCharsetTest.cpp
+        utf8CharsetTest.cpp
         base2Test.cpp
         base16Test.cpp
         defaultCharsetTest.cpp

--- a/euphony/src/main/cpp/tests/utf8CharsetTest.cpp
+++ b/euphony/src/main/cpp/tests/utf8CharsetTest.cpp
@@ -1,0 +1,63 @@
+#include <Definitions.h>
+#include <UTF8Charset.h>
+#include <gtest/gtest.h>
+
+#include <tuple>
+
+using namespace Euphony;
+
+typedef std::tuple<std::string, std::string> TestParamType;
+
+class UTF8CharsetTestFixture : public ::testing::TestWithParam<TestParamType> {
+
+public:
+    void openCharset() {
+        EXPECT_EQ(charset, nullptr);
+        charset = new UTF8Charset();
+        ASSERT_NE(charset, nullptr);
+    }
+
+    Charset *charset = nullptr;
+};
+
+TEST_P(UTF8CharsetTestFixture, EncodingTest) {
+    openCharset();
+
+    std::string source;
+    std::string expectedResult;
+
+    std::tie(source, expectedResult) = GetParam();
+
+    HexVector actualResult = charset->encode(source);
+    EXPECT_EQ(actualResult.toString(), expectedResult);
+}
+
+TEST_P(UTF8CharsetTestFixture, DecodingTest) {
+    openCharset();
+
+    std::string source;
+    std::string expectedResult;
+
+    std::tie(expectedResult, source) = GetParam();
+    HexVector hv = HexVector(source);
+
+    std::string actualResult = charset->decode(hv);
+    EXPECT_EQ(actualResult, expectedResult);
+}
+
+INSTANTIATE_TEST_CASE_P(
+        ChrasetDecodingTestSuite,
+        UTF8CharsetTestFixture,
+        ::testing::Values(
+                TestParamType("a", "61"),
+                TestParamType("b", "62"),
+                TestParamType("가", "eab080"),
+                TestParamType("각", "eab081"),
+                TestParamType("나", "eb8298"),
+                TestParamType("홍길동", "ed998deab8b8eb8f99"),
+                TestParamType("@XYZ", "4058595a"),
+                TestParamType(".com", "2e636f6d"),
+                TestParamType("서울특별시", "ec849cec9ab8ed8ab9ebb384ec8b9c"),
+                TestParamType("010-1234-5678", "3031302d313233342d35363738"),
+                TestParamType("36.5℃", "33362e35e28483")
+        ));


### PR DESCRIPTION
We added UTF8Charset class and test codes to support the Korean language of the eupony library.
When we tested with various test cases, it worked well without any problems.


![gdgd](https://user-images.githubusercontent.com/88221233/135973384-893bb3ba-0281-4578-98a0-5775d8f6ef88.png)

If there's anything wrong or need to be improved, please leave a comment! Thank you. :smile:

Co-Authored-By: SangYeon Min <judemin2087@naver.com>
Co-Authored-By: JK Park <kuro11pow2@gmail.com>

