### PR TITLE
Add code to print build_stdout after build is finished

### DIFF
--- a/euphony/build.gradle
+++ b/euphony/build.gradle
@@ -50,6 +50,25 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
+
+    gradle.buildFinished {
+        def abiArr = ['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64']
+        def resultStr = ""
+
+        for (abi in abiArr) {
+            def filePath = 'euphony/.cxx/cmake/debug/' + abi + '/android_gradle_build_stdout_targets.txt'
+            File file = new File(filePath)
+            def line;
+            file.withReader { reader ->
+                while ((line = reader.readLine()) != null) {
+                    if (line == '**** Gtest Success ****')
+                        resultStr += '\n> ' + abi + '/android_gradle_build_stdout_targets.txt\n' + line
+                }
+            }
+        }
+        if (resultStr != "")
+            println '\nPrint build_stdout' + resultStr
+    }
 }
 
 dependencies {

--- a/euphony/src/main/cpp/CMakeLists.txt
+++ b/euphony/src/main/cpp/CMakeLists.txt
@@ -26,6 +26,7 @@ set(EUPHONY_SRC
         arms/kiss_fftr.c
         core/source/AudioStreamCallback.cpp
         core/source/ASCIICharset.cpp
+        core/source/UTF16Charset.cpp
         core/source/Base2.cpp
         core/source/Base16.cpp
         core/source/Base16Exception.cpp

--- a/euphony/src/main/cpp/core/UTF16Charset.h
+++ b/euphony/src/main/cpp/core/UTF16Charset.h
@@ -11,6 +11,11 @@ namespace Euphony {
         ~UTF16Charset() = default;
         HexVector encode(std::string src);
         std::string decode(const HexVector &src);
+    private:
+        const u_int8_t BIT_COUNT_IN_HEX_NUM = 4;
+        const u_int8_t BYTE_COUNT = 2;
+        const u_int8_t HEX_NUM_COUNT = BYTE_COUNT * 8 / BIT_COUNT_IN_HEX_NUM;
+        const char16_t BIT_MASK = 0x000F;
     };
 }
 

--- a/euphony/src/main/cpp/core/UTF16Charset.h
+++ b/euphony/src/main/cpp/core/UTF16Charset.h
@@ -1,0 +1,17 @@
+#ifndef EUPHONY_UTF16CHARSET_H
+#define EUPHONY_UTF16CHARSET_H
+
+#include "Charset.h"
+
+namespace Euphony {
+    class UTF16Charset : public Charset {
+    public:
+        UTF16Charset() = default;
+        ~UTF16Charset() = default;
+
+        HexVector encode(std::string src);
+        std::string decode(const HexVector &src);
+    };
+}
+
+#endif //EUPHONY_UTF16CHARSET_H

--- a/euphony/src/main/cpp/core/UTF16Charset.h
+++ b/euphony/src/main/cpp/core/UTF16Charset.h
@@ -4,11 +4,11 @@
 #include "Charset.h"
 
 namespace Euphony {
+
     class UTF16Charset : public Charset {
     public:
         UTF16Charset() = default;
         ~UTF16Charset() = default;
-
         HexVector encode(std::string src);
         std::string decode(const HexVector &src);
     };

--- a/euphony/src/main/cpp/core/source/UTF16Charset.cpp
+++ b/euphony/src/main/cpp/core/source/UTF16Charset.cpp
@@ -1,0 +1,68 @@
+#include "../UTF16Charset.h"
+#include <sstream>
+#include <iomanip>
+#include <codecvt>
+#include <bitset>
+
+using namespace Euphony;
+
+const unsigned int BIT_COUNT_IN_HEX_NUM = 4;
+const unsigned int BYTE_COUNT = 2;
+const unsigned int HEX_NUM_COUNT = BYTE_COUNT * 8 / BIT_COUNT_IN_HEX_NUM;
+
+HexVector UTF16Charset::encode(std::string src)
+{
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
+    std::u16string utf16s = convert.from_bytes(src);
+    HexVector result = HexVector(2 * utf16s.size());
+
+    for (int char_idx = 0; char_idx < utf16s.size(); char_idx++)
+    {
+        char16_t now_char = utf16s[char_idx];
+        std::bitset<16> char_bits = std::bitset<16>(now_char);
+        std::vector<u_int8_t> tmp;
+        for (int hex_idx = 0; hex_idx < HEX_NUM_COUNT; hex_idx++)
+        {
+            u_int8_t hex_num = 0;
+            for (int bit_idx = 0; bit_idx < BIT_COUNT_IN_HEX_NUM; bit_idx++)
+            {
+                if (char_bits.test(BIT_COUNT_IN_HEX_NUM * hex_idx + bit_idx))
+                {
+                    hex_num += 1 << bit_idx;
+                }
+            }
+            tmp.push_back(hex_num);
+        }
+        for (auto iter = tmp.rbegin(); iter != tmp.rend(); iter++)
+        {
+            result.pushBack(*iter);
+        }
+    }
+
+    return result;
+}
+
+std::string UTF16Charset::decode(const HexVector &src)
+{
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
+    std::u16string utf16s = u"";
+    std::string result = "";
+    std::vector<u_int8_t> hexSource = src.getHexSource();
+    char16_t ch = 0;
+
+    for (int hex_idx = 0; hex_idx < hexSource.size() / HEX_NUM_COUNT; hex_idx++)
+    {
+        for (int bit_idx = 0; bit_idx < BIT_COUNT_IN_HEX_NUM; bit_idx++)
+        {
+            u_int8_t now_num = hexSource[BIT_COUNT_IN_HEX_NUM * hex_idx + bit_idx];
+            int add = now_num << (BYTE_COUNT * 8 - (bit_idx+1) * BIT_COUNT_IN_HEX_NUM);
+            ch += add;
+        }
+        utf16s += ch;
+        ch = 0;
+    }
+
+    result = convert.to_bytes(utf16s);
+
+    return result;
+}

--- a/euphony/src/main/cpp/core/source/UTF16Charset.cpp
+++ b/euphony/src/main/cpp/core/source/UTF16Charset.cpp
@@ -1,34 +1,22 @@
-#include "UTF16Charset.h"
-#include <bitset>
+#include "../UTF16Charset.h"
 #include <codecvt>
 #include <iomanip>
 
 using namespace Euphony;
-
-const unsigned int BIT_COUNT_IN_HEX_NUM = 4;
-const unsigned int BYTE_COUNT = 2;
-const unsigned int HEX_NUM_COUNT = BYTE_COUNT * 8 / BIT_COUNT_IN_HEX_NUM;
 
 HexVector UTF16Charset::encode(std::string src) {
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
     std::u16string utf16s = convert.from_bytes(src);
     HexVector result = HexVector(2 * utf16s.size());
 
-    for (int char_idx = 0; char_idx < utf16s.size(); char_idx++) {
-        char16_t ch = utf16s[char_idx];
-        std::bitset<16> char_bits = std::bitset<16>(ch);
-        std::vector<u_int8_t> tmp;
-        for (int hex_idx = 0; hex_idx < HEX_NUM_COUNT; hex_idx++) {
-            u_int8_t hex_num = 0;
-            for (int bit_idx = 0; bit_idx < BIT_COUNT_IN_HEX_NUM; bit_idx++) {
-                if (char_bits.test(BIT_COUNT_IN_HEX_NUM * hex_idx + bit_idx)) {
-                    hex_num += 1 << bit_idx;
-                }
-            }
-            tmp.push_back(hex_num);
+    for (char16_t ch : utf16s) {
+        std::vector<u_int8_t> halfByteBuffer;
+        for(int hexIdx = 0; hexIdx < HEX_NUM_COUNT; hexIdx++) {
+            halfByteBuffer.push_back(ch & BIT_MASK);
+            ch >>= BIT_COUNT_IN_HEX_NUM;
         }
-        for (auto iter = tmp.rbegin(); iter != tmp.rend(); iter++) {
-            result.pushBack(*iter);
+        for (auto it = halfByteBuffer.rbegin(); it != halfByteBuffer.rend(); it++) {
+            result.pushBack(*it);
         }
     }
 
@@ -41,13 +29,11 @@ std::string UTF16Charset::decode(const HexVector &src) {
     std::string result = "";
     std::vector<u_int8_t> hexSource = src.getHexSource();
 
-    for (int hex_idx = 0; hex_idx < hexSource.size() / HEX_NUM_COUNT; hex_idx++) {
-        char16_t ch = 0;
-        for (int bit_idx = 0; bit_idx < BIT_COUNT_IN_HEX_NUM; bit_idx++) {
-            u_int8_t n = hexSource[BIT_COUNT_IN_HEX_NUM * hex_idx + bit_idx];
-            u_int offset = (BYTE_COUNT * 8 - (bit_idx + 1) * BIT_COUNT_IN_HEX_NUM);
-            ch += n << offset;
-        }
+    for (int hexIdx = 0; hexIdx < hexSource.size(); hexIdx += HEX_NUM_COUNT) {
+        char16_t ch = hexSource[hexIdx];
+        ch = (ch << BIT_COUNT_IN_HEX_NUM) | hexSource[hexIdx + 1];
+        ch = (ch << BIT_COUNT_IN_HEX_NUM) | hexSource[hexIdx + 2];
+        ch = (ch << BIT_COUNT_IN_HEX_NUM) | hexSource[hexIdx + 3];
         utf16s += ch;
     }
 

--- a/euphony/src/main/cpp/core/source/UTF16Charset.cpp
+++ b/euphony/src/main/cpp/core/source/UTF16Charset.cpp
@@ -1,8 +1,7 @@
-#include "../UTF16Charset.h"
-#include <sstream>
-#include <iomanip>
-#include <codecvt>
+#include "UTF16Charset.h"
 #include <bitset>
+#include <codecvt>
+#include <iomanip>
 
 using namespace Euphony;
 
@@ -10,31 +9,25 @@ const unsigned int BIT_COUNT_IN_HEX_NUM = 4;
 const unsigned int BYTE_COUNT = 2;
 const unsigned int HEX_NUM_COUNT = BYTE_COUNT * 8 / BIT_COUNT_IN_HEX_NUM;
 
-HexVector UTF16Charset::encode(std::string src)
-{
+HexVector UTF16Charset::encode(std::string src) {
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
     std::u16string utf16s = convert.from_bytes(src);
     HexVector result = HexVector(2 * utf16s.size());
 
-    for (int char_idx = 0; char_idx < utf16s.size(); char_idx++)
-    {
-        char16_t now_char = utf16s[char_idx];
-        std::bitset<16> char_bits = std::bitset<16>(now_char);
+    for (int char_idx = 0; char_idx < utf16s.size(); char_idx++) {
+        char16_t ch = utf16s[char_idx];
+        std::bitset<16> char_bits = std::bitset<16>(ch);
         std::vector<u_int8_t> tmp;
-        for (int hex_idx = 0; hex_idx < HEX_NUM_COUNT; hex_idx++)
-        {
+        for (int hex_idx = 0; hex_idx < HEX_NUM_COUNT; hex_idx++) {
             u_int8_t hex_num = 0;
-            for (int bit_idx = 0; bit_idx < BIT_COUNT_IN_HEX_NUM; bit_idx++)
-            {
-                if (char_bits.test(BIT_COUNT_IN_HEX_NUM * hex_idx + bit_idx))
-                {
+            for (int bit_idx = 0; bit_idx < BIT_COUNT_IN_HEX_NUM; bit_idx++) {
+                if (char_bits.test(BIT_COUNT_IN_HEX_NUM * hex_idx + bit_idx)) {
                     hex_num += 1 << bit_idx;
                 }
             }
             tmp.push_back(hex_num);
         }
-        for (auto iter = tmp.rbegin(); iter != tmp.rend(); iter++)
-        {
+        for (auto iter = tmp.rbegin(); iter != tmp.rend(); iter++) {
             result.pushBack(*iter);
         }
     }
@@ -42,24 +35,20 @@ HexVector UTF16Charset::encode(std::string src)
     return result;
 }
 
-std::string UTF16Charset::decode(const HexVector &src)
-{
+std::string UTF16Charset::decode(const HexVector &src) {
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
     std::u16string utf16s = u"";
     std::string result = "";
     std::vector<u_int8_t> hexSource = src.getHexSource();
-    char16_t ch = 0;
 
-    for (int hex_idx = 0; hex_idx < hexSource.size() / HEX_NUM_COUNT; hex_idx++)
-    {
-        for (int bit_idx = 0; bit_idx < BIT_COUNT_IN_HEX_NUM; bit_idx++)
-        {
-            u_int8_t now_num = hexSource[BIT_COUNT_IN_HEX_NUM * hex_idx + bit_idx];
-            int add = now_num << (BYTE_COUNT * 8 - (bit_idx+1) * BIT_COUNT_IN_HEX_NUM);
-            ch += add;
+    for (int hex_idx = 0; hex_idx < hexSource.size() / HEX_NUM_COUNT; hex_idx++) {
+        char16_t ch = 0;
+        for (int bit_idx = 0; bit_idx < BIT_COUNT_IN_HEX_NUM; bit_idx++) {
+            u_int8_t n = hexSource[BIT_COUNT_IN_HEX_NUM * hex_idx + bit_idx];
+            u_int offset = (BYTE_COUNT * 8 - (bit_idx + 1) * BIT_COUNT_IN_HEX_NUM);
+            ch += n << offset;
         }
         utf16s += ch;
-        ch = 0;
     }
 
     result = convert.to_bytes(utf16s);

--- a/euphony/src/main/cpp/tests/CMakeLists.txt
+++ b/euphony/src/main/cpp/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ target_include_directories (gtest PUBLIC ${GOOGLETEST_ROOT}/include)
 add_executable(
         ${TEST_EUPHONY}
         asciiCharsetTest.cpp
+        utf16CharsetTest.cpp
         base2Test.cpp
         base16Test.cpp
         defaultCharsetTest.cpp

--- a/euphony/src/main/cpp/tests/utf16CharsetTest.cpp
+++ b/euphony/src/main/cpp/tests/utf16CharsetTest.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+#include <Definitions.h>
+#include <UTF16Charset.h>
+#include <tuple>
+
+using namespace Euphony;
+
+typedef std::tuple<std::string, std::string> TestParamType;
+
+class UTF16CharsetTestFixture : public ::testing::TestWithParam<TestParamType>
+{
+
+public:
+    void openCharset()
+    {
+        EXPECT_EQ(charset, nullptr);
+        charset = new UTF16Charset();
+        ASSERT_NE(charset, nullptr);
+    }
+
+    Charset *charset = nullptr;
+};
+
+TEST_P(UTF16CharsetTestFixture, EncodingTest)
+{
+openCharset();
+
+std::string source;
+std::string expectedResult;
+
+std::tie(source, expectedResult) = GetParam();
+
+HexVector actualResult = charset->encode(source);
+EXPECT_EQ(actualResult.toString(), expectedResult);
+}
+
+TEST_P(UTF16CharsetTestFixture, DecodingTest)
+{
+openCharset();
+
+std::string source;
+std::string expectedResult;
+
+std::tie(expectedResult, source) = GetParam();
+HexVector hv = HexVector(source);
+
+std::string actualResult = charset->decode(hv);
+EXPECT_EQ(actualResult, expectedResult);
+}
+
+INSTANTIATE_TEST_CASE_P(
+        ChrasetDecodingTestSuite,
+        UTF16CharsetTestFixture,
+        ::testing::Values(
+        TestParamType("가", "ac00"),
+        TestParamType("나", "b098"),
+        TestParamType("홍길동", "d64dae38b3d9"),
+        TestParamType("a", "0061"),
+        TestParamType("b", "0062"),
+        TestParamType("@XYZ", "004000580059005a"),
+        TestParamType(".com", "002e0063006f006d"),
+        TestParamType("서울특별시", "c11cc6b8d2b9bcc4c2dc"),
+        TestParamType("010-1234-5678", "003000310030002d0031003200330034002d0035003600370038"),
+        TestParamType("36.5℃", "00330036002e00352103")
+));

--- a/euphony/src/main/cpp/tests/utf16CharsetTest.cpp
+++ b/euphony/src/main/cpp/tests/utf16CharsetTest.cpp
@@ -1,18 +1,17 @@
-#include <gtest/gtest.h>
 #include <Definitions.h>
 #include <UTF16Charset.h>
+#include <gtest/gtest.h>
+
 #include <tuple>
 
 using namespace Euphony;
 
 typedef std::tuple<std::string, std::string> TestParamType;
 
-class UTF16CharsetTestFixture : public ::testing::TestWithParam<TestParamType>
-{
+class UTF16CharsetTestFixture : public ::testing::TestWithParam<TestParamType> {
 
 public:
-    void openCharset()
-    {
+    void openCharset() {
         EXPECT_EQ(charset, nullptr);
         charset = new UTF16Charset();
         ASSERT_NE(charset, nullptr);
@@ -21,45 +20,43 @@ public:
     Charset *charset = nullptr;
 };
 
-TEST_P(UTF16CharsetTestFixture, EncodingTest)
-{
-openCharset();
+TEST_P(UTF16CharsetTestFixture, EncodingTest) {
+    openCharset();
 
-std::string source;
-std::string expectedResult;
+    std::string source;
+    std::string expectedResult;
 
-std::tie(source, expectedResult) = GetParam();
+    std::tie(source, expectedResult) = GetParam();
 
-HexVector actualResult = charset->encode(source);
-EXPECT_EQ(actualResult.toString(), expectedResult);
+    HexVector actualResult = charset->encode(source);
+    EXPECT_EQ(actualResult.toString(), expectedResult);
 }
 
-TEST_P(UTF16CharsetTestFixture, DecodingTest)
-{
-openCharset();
+TEST_P(UTF16CharsetTestFixture, DecodingTest) {
+    openCharset();
 
-std::string source;
-std::string expectedResult;
+    std::string source;
+    std::string expectedResult;
 
-std::tie(expectedResult, source) = GetParam();
-HexVector hv = HexVector(source);
+    std::tie(expectedResult, source) = GetParam();
+    HexVector hv = HexVector(source);
 
-std::string actualResult = charset->decode(hv);
-EXPECT_EQ(actualResult, expectedResult);
+    std::string actualResult = charset->decode(hv);
+    EXPECT_EQ(actualResult, expectedResult);
 }
 
 INSTANTIATE_TEST_CASE_P(
         ChrasetDecodingTestSuite,
         UTF16CharsetTestFixture,
         ::testing::Values(
-        TestParamType("가", "ac00"),
-        TestParamType("나", "b098"),
-        TestParamType("홍길동", "d64dae38b3d9"),
-        TestParamType("a", "0061"),
-        TestParamType("b", "0062"),
-        TestParamType("@XYZ", "004000580059005a"),
-        TestParamType(".com", "002e0063006f006d"),
-        TestParamType("서울특별시", "c11cc6b8d2b9bcc4c2dc"),
-        TestParamType("010-1234-5678", "003000310030002d0031003200330034002d0035003600370038"),
-        TestParamType("36.5℃", "00330036002e00352103")
-));
+                TestParamType("가", "ac00"),
+                TestParamType("나", "b098"),
+                TestParamType("홍길동", "d64dae38b3d9"),
+                TestParamType("a", "0061"),
+                TestParamType("b", "0062"),
+                TestParamType("@XYZ", "004000580059005a"),
+                TestParamType(".com", "002e0063006f006d"),
+                TestParamType("서울특별시", "c11cc6b8d2b9bcc4c2dc"),
+                TestParamType("010-1234-5678", "003000310030002d0031003200330034002d0035003600370038"),
+                TestParamType("36.5℃", "00330036002e00352103")
+        ));


### PR DESCRIPTION
# Description
Build_stdout of all ABIs is always updated whenever built. And the ABI in which the device is not connected or failed to perform the unit test does not include "Gtest Success". Therefore, build_stdout is printed only when "Gtest Success" is included.

# Result
![image](https://user-images.githubusercontent.com/47289893/136442007-48789585-0a0a-4c8d-bdec-3addd9210c71.png)
If multiple devices are connected at the same time, they are all printed.

![image](https://user-images.githubusercontent.com/47289893/136440004-08ffaca3-03aa-4f88-9888-82a64c0a31e2.png)
If there is no connected device, nothing will be printed.

# Question
![image](https://user-images.githubusercontent.com/47289893/136441301-6d959822-4248-4e96-84c0-32aaaab944e5.png)
Why are commits that have already been merged added to the PR?
The three commits above are already merged.