### PR TITLE
Add code to print build_stdout after build is finished

### DIFF
--- a/euphony/build.gradle
+++ b/euphony/build.gradle
@@ -53,21 +53,23 @@ android {
 
     gradle.buildFinished {
         def abiArr = ['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64']
-        def resultStr = ""
-
+        def logfile = "android_gradle_build_stdout_targets.txt"
+        def lastWordIfThereAreNoDevice = "Linking"
+        def resultStr = "\n"
+        def noDevice = true
         for (abi in abiArr) {
-            def filePath = 'euphony/.cxx/cmake/debug/' + abi + '/android_gradle_build_stdout_targets.txt'
-            File file = new File(filePath)
-            def line;
-            file.withReader { reader ->
-                while ((line = reader.readLine()) != null) {
-                    if (line == '**** Gtest Success ****')
-                        resultStr += '\n> ' + abi + '/android_gradle_build_stdout_targets.txt\n' + line
-                }
-            }
+            def filePath = "euphony/.cxx/cmake/debug/$abi/$logfile"
+            def lines = new File(filePath).readLines()
+            if (lines.get(lines.size() - 1).contains(lastWordIfThereAreNoDevice))
+                continue
+            noDevice = false
+            resultStr += "> $abi/$logfile\n"
+            resultStr += lines.join("\n")
         }
-        if (resultStr != "")
-            println '\nPrint build_stdout' + resultStr
+        if (noDevice)
+            println "The build was successful, not verified by unit tests. For unit testing, connect a virtual device or Android device to adb."
+        else
+            println "Print build_stdout $resultStr"
     }
 }
 

--- a/euphony/build.gradle
+++ b/euphony/build.gradle
@@ -50,6 +50,25 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
+
+    gradle.buildFinished {
+        def abiArr = ['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64']
+        def resultStr = ""
+
+        for (abi in abiArr) {
+            def filePath = 'euphony/.cxx/cmake/debug/' + abi + '/android_gradle_build_stdout_targets.txt'
+            File file = new File(filePath)
+            def line;
+            file.withReader { reader ->
+                while ((line = reader.readLine()) != null) {
+                    if (line == '**** Gtest Success ****')
+                        resultStr += '\n> ' + abi + '/android_gradle_build_stdout_targets.txt\n' + line
+                }
+            }
+        }
+        if (resultStr != "")
+            println '\nPrint build_stdout' + resultStr
+    }
 }
 
 dependencies {

--- a/euphony/src/main/cpp/tests/cmake.run.test.script
+++ b/euphony/src/main/cpp/tests/cmake.run.test.script
@@ -4,11 +4,13 @@ execute_process(COMMAND ${ADB} -s ${SERIAL} shell LD_LIBRARY_PATH=${TARGET_TEST_
                 ERROR_VARIABLE GTEST_ERROR_OUTPUT
                 )
 
+string(STRIP ${GTEST_EUPHONY_OUTPUT} GTEST_EUPHONY_OUTPUT)
+string(REPLACE "\n\n" "\r[NEXT]\r" GTEST_EUPHONY_OUTPUT ${GTEST_EUPHONY_OUTPUT})
+string(REPLACE "\n" "\r" GTEST_EUPHONY_OUTPUT ${GTEST_EUPHONY_OUTPUT})
+
 if( ${GTEST_RESULT} GREATER 0 )
-    string(STRIP ${GTEST_EUPHONY_OUTPUT} GTEST_EUPHONY_OUTPUT)
-    string(REPLACE "\n\n" "\r[NEXT]\r" GTEST_EUPHONY_OUTPUT ${GTEST_EUPHONY_OUTPUT})
-    string(REPLACE "\n" "\r" GTEST_EUPHONY_OUTPUT ${GTEST_EUPHONY_OUTPUT})
     message(FATAL_ERROR "** Gtest Failure (${GTEST_RESULT}) **\r${GTEST_EUPHONY_OUTPUT}")
 else()
+    message(${GTEST_EUPHONY_OUTPUT})
     message("**** Gtest Success ****")
 endif()


### PR DESCRIPTION
# Description
Build_stdout of all ABIs is always updated whenever built. And the ABI in which the device is not connected or failed to perform the unit test does not include "Gtest Success". Therefore, build_stdout is printed only when "Gtest Success" is included.

# Result
![image](https://user-images.githubusercontent.com/47289893/136442007-48789585-0a0a-4c8d-bdec-3addd9210c71.png)
If multiple devices are connected at the same time, they are all printed.

![image](https://user-images.githubusercontent.com/47289893/136440004-08ffaca3-03aa-4f88-9888-82a64c0a31e2.png)
If there is no connected device, nothing will be printed.