### PR TITLE
Update tests/CMakeLists.txt to remove unnecessary files after gtest

### DIFF
--- a/euphony/src/main/cpp/tests/CMakeLists.txt
+++ b/euphony/src/main/cpp/tests/CMakeLists.txt
@@ -72,6 +72,11 @@ foreach(SERIAL ${ADB_DEVICE_LIST})
         add_custom_command(TARGET ${TEST_EUPHONY} POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -DADB:STRING="${ADB}" -DSERIAL:STRING="${SERIAL}" -DTARGET_TEST_LIB_DIR:STRING="${TARGET_TEST_LIB_DIR}" -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake.run.test.script
                 )
+
+        # Remove gtest executable files in device.
+        add_custom_command(TARGET ${TEST_EUPHONY} POST_BUILD
+                COMMAND ${ADB} -s ${SERIAL} shell rm -r ${TARGET_TEST_LIB_DIR}
+                )
     endif()
 endforeach()
 


### PR DESCRIPTION
I added custom command in tests/CMakeLists.txt to remove not necessary files after the gtest is done.
Please check Discussion #98 , if you want to see more details. :-)