### PR TITLE
Remove duplication of base32Test.cpp in CMakeLists.txt

### DIFF
--- a/euphony/src/main/cpp/tests/CMakeLists.txt
+++ b/euphony/src/main/cpp/tests/CMakeLists.txt
@@ -14,7 +14,6 @@ add_executable(
         utf8CharsetTest.cpp
         utf16CharsetTest.cpp
         base2Test.cpp
-        base32Test.cpp
         base16Test.cpp
         base32Test.cpp
         base64Test.cpp


### PR DESCRIPTION
Remove duplication of base32Test.cpp in CMakeLists.txt

https://github.com/euphony-io/euphony/blob/8d155c528a01a42eb39fb91c77e4fa6124d6928f/euphony/src/main/cpp/tests/CMakeLists.txt#L18-L20