### PR TITLE
bug: publish property condition check

### DIFF
--- a/euphony/build.gradle
+++ b/euphony/build.gradle
@@ -76,7 +76,15 @@ android {
     }
 }
 
-apply from: "publish.gradle"
+if ( project.hasProperty("ossrhUsername")
+        && project.hasProperty("ossrhPassword")
+        &&project.hasProperty("sonatypeStagingProfileId")
+        && project.hasProperty("signing.keyId")
+        && project.hasProperty("signing.key")
+        && project.hasProperty("signing.password")
+) {
+    apply from: "publish.gradle"
+}
 
 dependencies {
     implementation 'com.google.oboe:oboe:1.6.1'

--- a/euphony/build.gradle
+++ b/euphony/build.gradle
@@ -78,7 +78,7 @@ android {
 
 if ( project.hasProperty("ossrhUsername")
         && project.hasProperty("ossrhPassword")
-        &&project.hasProperty("sonatypeStagingProfileId")
+        && project.hasProperty("sonatypeStagingProfileId")
         && project.hasProperty("signing.keyId")
         && project.hasProperty("signing.key")
         && project.hasProperty("signing.password")

--- a/publish-root.gradle
+++ b/publish-root.gradle
@@ -18,12 +18,20 @@ if (secretPropsFile.exists()) {
 nexusPublishing {
     repositories {
         sonatype {
-            stagingProfileId = sonatypeStagingProfileId
-            username = ossrhUsername
-            password = ossrhPassword
+            if ( project.hasProperty("ossrhUsername")
+                    && project.hasProperty("ossrhPassword")
+                    &&project.hasProperty("sonatypeStagingProfileId")
+                    && project.hasProperty("signing.keyId")
+                    && project.hasProperty("signing.key")
+                    && project.hasProperty("signing.password")
+            ) {
+                stagingProfileId = sonatypeStagingProfileId
+                username = ossrhUsername
+                password = ossrhPassword
 
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+                nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+                snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            }
         }
     }
 }

--- a/publish-root.gradle
+++ b/publish-root.gradle
@@ -20,7 +20,7 @@ nexusPublishing {
         sonatype {
             if ( project.hasProperty("ossrhUsername")
                     && project.hasProperty("ossrhPassword")
-                    &&project.hasProperty("sonatypeStagingProfileId")
+                    && project.hasProperty("sonatypeStagingProfileId")
                     && project.hasProperty("signing.keyId")
                     && project.hasProperty("signing.key")
                     && project.hasProperty("signing.password")


### PR DESCRIPTION
If there are no properties about publishing in local-pc, build will fail with the message below.

```
Caused by: groovy.lang.MissingPropertyException: Could not get unknown property 'sonatypeStagingProfileId' for object of type io.github.gradlenexus.publishplugin.NexusRepository.
```

Actually, upstream repository build will be OK. because those properties are defined in action secret variables.

After patch of this, there is no errors :)