### PR TITLE
Resolved fail case of unit-test for ASK

### DIFF
--- a/euphony/src/main/cpp/core/Wave.h
+++ b/euphony/src/main/cpp/core/Wave.h
@@ -33,8 +33,8 @@ namespace Euphony {
         void setHz(int hz);
         int getSize() const;
         void setSize(int size);
-        float getAmpSize() const;
-        void setAmpSize(float size);
+        float getAmplitude() const;
+        void setAmplitude(float amplitude);
         int getSampleRate() const;
         void setSampleRate(int sampleRate);
 
@@ -48,7 +48,7 @@ namespace Euphony {
 
         int mHz;
         int mSize;
-        float mAmpSize;
+        float mAmplitude;
         int sampleRate;
         CrossfadeType crossfadeType;
         std::vector<float> mSource;

--- a/euphony/src/main/cpp/core/WaveBuilder.h
+++ b/euphony/src/main/cpp/core/WaveBuilder.h
@@ -11,7 +11,7 @@ namespace Euphony {
     public:
         WaveBuilder& vibratesAt(int hz);
         WaveBuilder& setSize(int size);
-        WaveBuilder& setAmpSize(float size);
+        WaveBuilder& setAmplitude(float amplitude);
         WaveBuilder& setCrossfade(CrossfadeType type);
         WaveBuilder& setSampleRate(int sampleRate);
         std::shared_ptr<Wave> build();

--- a/euphony/src/main/cpp/core/source/ASK.cpp
+++ b/euphony/src/main/cpp/core/source/ASK.cpp
@@ -53,9 +53,9 @@ shared_ptr<Packet> ASK::demodulate(const WaveList& waveList) {
     const int startIdx = getStartFreqIdx();
 
     for(const auto& wave : waveList) {
-        auto vectorInt16Source = wave->getInt16Source();
-        int16_t* int16Source = &vectorInt16Source[0];
-        auto spectrums = fftModel->makeSpectrum(int16Source);
+        auto vectorFloatSource = wave->getSource();
+        float* floatSource = &vectorFloatSource[0];
+        auto spectrums = fftModel->makeSpectrum(floatSource);
         float *resultBuf = spectrums.amplitudeSpectrum;
         if(resultBuf[startIdx] > threshold)
             hexVector.pushBack(1);

--- a/euphony/src/main/cpp/core/source/ASK.cpp
+++ b/euphony/src/main/cpp/core/source/ASK.cpp
@@ -35,7 +35,7 @@ WaveList ASK::modulate(std::string code) {
                                 .vibratesAt(kStandardFrequency)
                                 .setSize(kBufferSize)
                                 .setCrossfade(BOTH)
-                                .setAmpSize(c-'0')
+                                .setAmplitude(c - '0')
                                 .build()
                 );
                 break;

--- a/euphony/src/main/cpp/core/source/Wave.cpp
+++ b/euphony/src/main/cpp/core/source/Wave.cpp
@@ -11,7 +11,7 @@ using namespace Euphony;
 Wave::Wave()
 : mHz(0)
 , mSize(0)
-, mAmpSize(1)
+, mAmplitude(1)
 , sampleRate(kSampleRate)
 , crossfadeType(NONE)
 {}
@@ -19,7 +19,7 @@ Wave::Wave()
 Wave::Wave(int hz, int bufferSize)
         : mHz(hz)
         , mSize(bufferSize)
-        , mAmpSize(1)
+        , mAmplitude(1)
         , sampleRate(kSampleRate)
         , crossfadeType(NONE)
 {
@@ -29,7 +29,7 @@ Wave::Wave(int hz, int bufferSize)
 Wave::Wave(int hz, int bufferSize, int sampleRate)
 : mHz(hz)
 , mSize(bufferSize)
-, mAmpSize(1)
+, mAmplitude(1)
 , sampleRate(sampleRate)
 , crossfadeType(NONE)
 {
@@ -39,7 +39,7 @@ Wave::Wave(int hz, int bufferSize, int sampleRate)
 Wave::Wave(const float *src, int bufferSize)
         : mHz(0)
         , mSize(bufferSize)
-        , mAmpSize(1)
+        , mAmplitude(1)
         , sampleRate(kSampleRate)
         , crossfadeType(NONE)
 {
@@ -51,7 +51,7 @@ Wave::Wave(const float *src, int bufferSize)
 Wave::Wave(const float *src, int bufferSize, int sampleRate)
 : mHz(0)
 , mSize(bufferSize)
-, mAmpSize(1)
+, mAmplitude(1)
 , sampleRate(sampleRate)
 , crossfadeType(NONE)
 {
@@ -63,7 +63,7 @@ Wave::Wave(const float *src, int bufferSize, int sampleRate)
 Wave::Wave(const Wave& copy)
 : mHz(copy.mHz)
 , mSize(copy.mSize)
-, mAmpSize(copy.mAmpSize)
+, mAmplitude(copy.mAmplitude)
 , sampleRate(copy.sampleRate)
 , crossfadeType(copy.crossfadeType)
 {
@@ -85,7 +85,7 @@ void Wave::oscillate() {
         float phase = 0.0;
 
         for(int i = 0; i < this->mSize; ++i) {
-            mSource.push_back(sin(phase) * mAmpSize);
+            mSource.push_back(sin(phase) * mAmplitude);
             phase += mPhaseIncrement;
             if(phase > kTwoPi) phase -= kTwoPi;
         }
@@ -115,7 +115,7 @@ void Wave::oscillate() {
 void Wave::oscillate(int hz, int size) {
     this->setHz(hz);
     this->setSize(size);
-    this->setAmpSize(1);
+    this->setAmplitude(1);
     this->oscillate();
 }
 
@@ -136,12 +136,12 @@ void Wave::setSize(int size) {
     mSource.reserve(size);
 }
 
-float Euphony::Wave::getAmpSize() const {
-    return mAmpSize;
+float Euphony::Wave::getAmplitude() const {
+    return mAmplitude;
 }
 
-void Euphony::Wave::setAmpSize(float size) {
-    mAmpSize = size;
+void Euphony::Wave::setAmplitude(float amplitude) {
+    mAmplitude = amplitude;
 }
 
 int Wave::getSampleRate() const {

--- a/euphony/src/main/cpp/core/source/WaveBuilder.cpp
+++ b/euphony/src/main/cpp/core/source/WaveBuilder.cpp
@@ -13,8 +13,8 @@ WaveBuilder& WaveBuilder::setSize(int size) {
     return *this;
 }
 
-WaveBuilder& WaveBuilder::setAmpSize(float size) {
-    wave.setAmpSize(size);
+WaveBuilder& WaveBuilder::setAmplitude(float amplitude) {
+    wave.setAmplitude(amplitude);
     return *this;
 }
 

--- a/euphony/src/main/cpp/tests/ASKTest.cpp
+++ b/euphony/src/main/cpp/tests/ASKTest.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 #include <Definitions.h>
 #include <ASK.h>
-#include <FFTProcessor.h>
 #include <tuple>
 #include <ASCIICharset.h>
 #include <HexVector.h>
@@ -21,7 +20,6 @@ public:
     }
 
     ASK* ask = nullptr;
-    FFTProcessor* fft = nullptr;
 };
 
 TEST_P(ASKTestFixture, ASKModulationStringTest)


### PR DESCRIPTION
From `v0.8.0.1`, 
It is a problem that unit-test of ASK(ASKTest.cpp) does not occur as the internal implementation of the function is removed.

Below is update summary.
- From this PR, ASK is using float source to make spectrum. 
- Renamed `ampSize` to `amplitude` in `Wave` class.