### PR TITLE
Add EuTimer to implement timeout for EuRxManager (#200)

### DIFF
--- a/euphony/src/main/java/co/euphony/util/EuTimeOutListener.kt
+++ b/euphony/src/main/java/co/euphony/util/EuTimeOutListener.kt
@@ -1,0 +1,5 @@
+package co.euphony.util
+
+fun interface EuTimeOutListener {
+    fun onTimeOut()
+}

--- a/euphony/src/main/java/co/euphony/util/EuTimer.kt
+++ b/euphony/src/main/java/co/euphony/util/EuTimer.kt
@@ -1,0 +1,39 @@
+package co.euphony.util
+
+import android.util.Log
+import java.util.*
+
+class EuTimer(
+    private val thread: Thread,
+    private val timeOutListener: EuTimeOutListener
+) {
+
+    companion object {
+        private const val LOG = "EuTimer"
+    }
+
+    fun start(timeout: Long) {
+        if (timeout <= 0) {
+            Log.w(LOG, "timeout must be a number greater than 0")
+            return
+        }
+
+        val timer = Timer()
+        val timeOutTask = TimeOutTask(timer)
+        timer.schedule(timeOutTask, timeout)
+    }
+
+    inner class TimeOutTask(
+        private val timer: Timer
+    ) : TimerTask() {
+
+        override fun run() {
+            if (thread.isAlive) {
+                Log.e(LOG, "Your job(${Thread.currentThread().name}) is interrupted by timeout")
+                thread.interrupt()
+                timer.cancel()
+                timeOutListener.onTimeOut()
+            }
+        }
+    }
+}

--- a/euphony/src/main/java/co/euphony/util/EuTimer.kt
+++ b/euphony/src/main/java/co/euphony/util/EuTimer.kt
@@ -23,7 +23,7 @@ class EuTimer(
         timer.schedule(timeOutTask, timeout)
     }
 
-    inner class TimeOutTask(
+    private inner class TimeOutTask(
         private val timer: Timer
     ) : TimerTask() {
 

--- a/euphony/src/test/java/euphony/lib/util/EuTimerTest.kt
+++ b/euphony/src/test/java/euphony/lib/util/EuTimerTest.kt
@@ -1,0 +1,35 @@
+package euphony.lib.util
+
+import co.euphony.util.EuTimer
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class EuTimerTest {
+
+    private val infiniteLoopJob: Thread = Thread {
+        try {
+            while (true) {
+                println(System.currentTimeMillis())
+                Thread.sleep(500)
+            }
+        } catch (e: InterruptedException) {
+            e.printStackTrace()
+        }
+    }
+
+    @Before
+    fun setUp() {
+        infiniteLoopJob.start()
+    }
+
+    @Test
+    fun testStart() {
+        val euTimer = EuTimer(infiniteLoopJob) {}
+        euTimer.start(2000L)
+        assertEquals(true, infiniteLoopJob.isAlive)
+
+        Thread.sleep(2100L)
+        assertEquals(false, infiniteLoopJob.isAlive)
+    }
+}

--- a/euphony/src/test/java/euphony/lib/util/EuTimerTest.kt
+++ b/euphony/src/test/java/euphony/lib/util/EuTimerTest.kt
@@ -1,6 +1,7 @@
 package euphony.lib.util
 
 import co.euphony.util.EuTimer
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -21,6 +22,13 @@ class EuTimerTest {
     @Before
     fun setUp() {
         infiniteLoopJob.start()
+    }
+
+    @After
+    fun finishTest() {
+        if (infiniteLoopJob.isAlive) {
+            infiniteLoopJob.interrupt()
+        }
     }
 
     @Test


### PR DESCRIPTION
* Related Issue : #200 

I implemented `EuTimer` class for timeout by using [TimerTask](https://docs.oracle.com/javase/7/docs/api/java/util/TimerTask.html).
It can be applied like this in RxEuManager,
```
mListenThread.start();
EuTimer euTimer = new EuTimer(mListenThread, () -> { 
    mListenThread = null;
});
euTimer.start(timeout);
```
but if #217 is merged, the form of listen() can change.
So I only upload EuTimer's code to avoid conflicts
Hope you give me a feedback!