### PR TITLE
Optimize Github Action for Compose tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
-      with:
-        distribution: adopt
-        java-version: 11
+        with:
+          distribution: adopt
+          java-version: 11
 
-    - name: Build with Gradle
-      run: ./gradlew build
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,15 +14,43 @@ on:
       - '**.md'
 
 jobs:
+  test:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            ui:
+              - '**/ui/**'
+
+      - name: Set up JDK 11
+        if: steps.changes.outputs.ui == 'true'
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Run Android Tests
+        if: steps.changes.outputs.ui == 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          script: ./gradlew euphony:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.package=co.euphony.ui
+          arch: x86_64
+          target: google_apis
+
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
       with:
         distribution: adopt
         java-version: 11


### PR DESCRIPTION
I solved the issue #226 
I used [android emulator runner](https://github.com/marketplace/actions/android-emulator-runner).
When I personally tested, it took about 20 minutes. 
I didn't expect that testing with an emulator takes so long time like this. 💦
<img width="995" alt="스크린샷 2022-09-06 오후 11 30 07" src="https://user-images.githubusercontent.com/35446215/188668181-74f70c04-800c-4130-ae18-2e6cc6a2ed88.png">
