### PR TITLE
Update documentation for v0.8.1.2

### DIFF
--- a/PREREQUISITE.md
+++ b/PREREQUISITE.md
@@ -36,13 +36,13 @@ There are 3 ways adding euphony to your project.
 dependencies {
 	// other dependencies
 	// ...
-	implementation 'co.euphony.lib:euphony:0.8.1.1'
+	implementation 'co.euphony.lib:euphony:0.8.1.2'
 }
 ```
 
 ### 1.2 Import the aar/jar file directly
 
-1. Download `euphony.aar` : [MavenCentral euphony artifact](https://search.maven.org/artifact/co.euphony.lib/euphony/0.8.1.1/aar) follow the link and download aar file.
+1. Download `euphony.aar` : [MavenCentral euphony artifact](https://search.maven.org/artifact/co.euphony.lib/euphony/0.8.1.2/aar) follow the link and download aar file.
 2. Put `euphony.aar` file in `libs` folder.
 
 <img width="392" alt="aar_002_auto_x2_colored_toned" src="https://user-images.githubusercontent.com/27720475/130187177-b97b55ef-158a-4975-b0f8-b9e8bfdc5886.png">
@@ -57,7 +57,7 @@ repositories {
 }
 
 dependencies {
-    implementation name: 'euphony-0.8.1.1', ext: 'aar'
+    implementation name: 'euphony-0.8.1.2', ext: 'aar'
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Euphony provides a handiness library designed to communicate with other devices(
 1) build.gradle in app module
 ```gradle
 dependencies {
-    implementation 'co.euphony.lib:euphony:0.8.1.1'
+    implementation 'co.euphony.lib:euphony:0.8.1.2'
 }
 ```
 

--- a/euphony/publish.gradle
+++ b/euphony/publish.gradle
@@ -3,7 +3,7 @@ apply plugin: 'signing'
 
 def LIB_GROUP_ID = 'co.euphony.lib'
 def LIB_ARTIFACT_ID = 'euphony'
-def LIB_VERSION = '0.8.1.1'
+def LIB_VERSION = '0.8.1.2'
 
 task androidSourcesJar(type: Jar) {
     archiveClassifier.set('sources')


### PR DESCRIPTION
Now, euphony `v0.8.1.2` has published in `maven central`.
refer to https://search.maven.org/artifact/co.euphony.lib/euphony/0.8.1.1/aar

- `v0.8.1.2` release note : https://github.com/euphony-io/euphony/releases/tag/v0.8.1.2

From this, we can import `v0.8.1.2` in `build.gradle` easily.

```groovy
dependencies {
    implementation 'co.euphony.lib:euphony:0.8.1.2'
}
```

I updated markdown documentation below.
 - `README.md`
 - `PREREQUISITE.md`
 - `publish.gradle`

PS. Thanks for contribution @sunyeongan @zion830 